### PR TITLE
fix(proyectos): ajustar ancho del combo de estado para alinear botones

### DIFF
--- a/src/app/modules/projects/components/list-project/list-project.component.scss
+++ b/src/app/modules/projects/components/list-project/list-project.component.scss
@@ -136,7 +136,7 @@ td.mat-cell {
 
 .status-select,
 .project-status-select {
-  min-width: 180px;
+  width: 180px;
   margin-top: 19px;
 }
 


### PR DESCRIPTION
Closes #402
Se redujo el `min-width` del combo de estado en la vista de proyectos a un tamaño menor para evitar que empuje los botones de "Descargar proyectos" y "Agregar nuevo" a la siguiente línea.